### PR TITLE
Allow more memberlist configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,8 @@ type SidecarConfig struct {
 	StatsAddr            string        `envconfig:"STATS_ADDR"`
 	PushPullInterval     time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
 	GossipMessages       int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
-	GossipInterval		 time.Duration `envconfig:"GOSSUP_INTERVAL" default:"200ms"`
+	GossipInterval		 time.Duration `envconfig:"GOSSIP_INTERVAL" default:"200ms"`
+	HandoffQueueDepth    int           `envconfig:"HANDOFF_QUEUE_DEPTH" default:"1024"`
 	LoggingFormat        string        `envconfig:"LOGGING_FORMAT"`
 	LoggingLevel         string        `envconfig:"LOGGING_LEVEL" default:"info"`
 	DefaultCheckEndpoint string        `envconfig:"DEFAULT_CHECK_ENDPOINT" default:"/version"`

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type SidecarConfig struct {
 	StatsAddr            string        `envconfig:"STATS_ADDR"`
 	PushPullInterval     time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
 	GossipMessages       int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
+	GossipInterval		 time.Duration `envconfig:"GOSSUP_INTERVAL" default:"200ms"`
 	LoggingFormat        string        `envconfig:"LOGGING_FORMAT"`
 	LoggingLevel         string        `envconfig:"LOGGING_LEVEL" default:"info"`
 	DefaultCheckEndpoint string        `envconfig:"DEFAULT_CHECK_ENDPOINT" default:"/version"`

--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,7 @@ type SidecarConfig struct {
 	StatsAddr            string        `envconfig:"STATS_ADDR"`
 	PushPullInterval     time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
 	GossipMessages       int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
-	GossipInterval		 time.Duration `envconfig:"GOSSIP_INTERVAL" default:"200ms"`
+	GossipInterval       time.Duration `envconfig:"GOSSIP_INTERVAL" default:"200ms"`
 	HandoffQueueDepth    int           `envconfig:"HANDOFF_QUEUE_DEPTH" default:"1024"`
 	LoggingFormat        string        `envconfig:"LOGGING_FORMAT"`
 	LoggingLevel         string        `envconfig:"LOGGING_LEVEL" default:"info"`

--- a/main.go
+++ b/main.go
@@ -247,6 +247,7 @@ func configureMemberlist(config *config.Config, state *catalog.ServicesState) *m
 	if config.Sidecar.GossipMessages != 0 {
 		mlConfig.GossipMessages = config.Sidecar.GossipMessages
 	}
+	mlConfig.GossipInterval = config.Sidecar.GossipInterval
 
 	// Make sure we pass on the cluster name to Memberlist
 	mlConfig.ClusterName = config.Sidecar.ClusterName

--- a/main.go
+++ b/main.go
@@ -248,6 +248,7 @@ func configureMemberlist(config *config.Config, state *catalog.ServicesState) *m
 		mlConfig.GossipMessages = config.Sidecar.GossipMessages
 	}
 	mlConfig.GossipInterval = config.Sidecar.GossipInterval
+	mlConfig.HandoffQueueDepth = config.Sidecar.HandoffQueueDepth
 
 	// Make sure we pass on the cluster name to Memberlist
 	mlConfig.ClusterName = config.Sidecar.ClusterName

--- a/main.go
+++ b/main.go
@@ -361,7 +361,12 @@ func main() {
 		go proxy.Watch(state)
 	}
 
-	go announceMembers(list, state)
+	// This is kind of expensive because it looks at the state and formats text
+	// output on an ongoing basis. Only run in debug mode.
+	if config.Debug {
+		go announceMembers(list, state)
+	}
+
 	go state.BroadcastServices(serviceFunc, servicesLooper)
 	go state.BroadcastTombstones(serviceFunc, tombstoneLooper)
 	go state.TrackNewServices(serviceFunc, trackingLooper)

--- a/main.go
+++ b/main.go
@@ -299,8 +299,9 @@ func main() {
 	exitWithError(err, "Failed to create memberlist")
 
 	// Join an existing cluster by specifying at least one known member.
-	_, err = list.Join(config.Sidecar.Seeds)
+	nodeCount, err := list.Join(config.Sidecar.Seeds)
 	exitWithError(err, "Failed to join cluster")
+	log.Info("Joined cluster with %d nodes contacted", nodeCount)
 
 	// Set up a bunch of go-director Loopers to run our
 	// background goroutines


### PR DESCRIPTION
We need to be able to configure more items in the memberlist config. This allows changing both the handoff buffer size and the gossip interval.