### PR TITLE
Better filter the services we want to announce

### DIFF
--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -54,7 +54,13 @@ func (m *mockK8sDiscoveryCommand) GetServices() ([]byte, error) {
 	               {
 	                  "port" : 10007,
 	                  "protocol" : "TCP",
-	                  "targetPort" : 8088
+	                  "targetPort" : 8088,
+					  "nodePort": 38088
+	               },
+	               {
+	                  "port" : 10008,
+	                  "protocol" : "TCP",
+	                  "targetPort" : 8089
 	               }
 	            ]
 	         }
@@ -155,7 +161,7 @@ func Test_K8sGetServices(t *testing.T) {
 			So(disco.discoveredSvcs, ShouldNotBeNil)
 			So(disco.discoveredSvcs, ShouldNotEqual, &K8sServices{})
 			So(len(disco.discoveredSvcs.Items), ShouldEqual, 1)
-			So(len(disco.discoveredSvcs.Items[0].Spec.Ports), ShouldEqual, 1)
+			So(len(disco.discoveredSvcs.Items[0].Spec.Ports), ShouldEqual, 2)
 		})
 
 		Convey("call the command and logs errors", func() {


### PR DESCRIPTION
This filters down the services to those which:

 * Have a `NodePort` defined since this is required for this method of announcement
 * Have a Label called `ServiceName` so we can be sure this is a service we want to announce