### PR TITLE
Kubernetes: Support Discovery Only for this Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ Defaults are in bold at the end of the line:
  * `KUBE_TIMEOUT`: How long until we time out calling the Kube API? **`3s`**
  * `CREDS_PATH`: Where do we find the token file containing API auth credentials?
    **`/var/run/secrets/kubernetes.io/serviceaccount`**
+ * `ANNOUNCE_ALL_NODES`: Should we query the API and announce every node is running
+   the service? This is useful to represent the K8s cluster with a single Sidecar.
+   **`false`**
 
 ### Ports
 

--- a/config/config.go
+++ b/config/config.go
@@ -66,11 +66,12 @@ type StaticConfig struct {
 }
 
 type K8sAPIConfig struct {
-	KubeAPIIP   string        `envconfig:"KUBE_API_IP" default:"127.0.0.1"`
-	KubeAPIPort int           `envconfig:"KUBE_API_PORT" default:"8080"`
-	Namespace   string        `envconfig:"NAMESPACE" default:"default"`
-	KubeTimeout time.Duration `envconfig:"KUBE_TIMEOUT" default:"3s"`
-	CredsPath   string        `envconfig:"CREDS_PATH" default:"/var/run/secrets/kubernetes.io/serviceaccount"`
+	KubeAPIIP        string        `envconfig:"KUBE_API_IP" default:"127.0.0.1"`
+	KubeAPIPort      int           `envconfig:"KUBE_API_PORT" default:"8080"`
+	Namespace        string        `envconfig:"NAMESPACE" default:"default"`
+	KubeTimeout      time.Duration `envconfig:"KUBE_TIMEOUT" default:"3s"`
+	CredsPath        string        `envconfig:"CREDS_PATH" default:"/var/run/secrets/kubernetes.io/serviceaccount"`
+	AnnounceAllNodes bool          `envconfig:"ANNOUNCE_ALL_NODES" default:"false"`
 }
 
 type Config struct {


### PR DESCRIPTION
Previously we only supported announcing Sidecar services on every node. This will now only announce for the node on which the Sidecar is running by default. You can override this behavior with `ANNOUNCE_ALL_NODES="true"`.