### PR TITLE
Ignore records older than TOMBSTONE_LIFESPAN

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -297,7 +297,7 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 	defer state.Unlock()
 
 	// Some weird edge cases can cause very old stuff to get broadcast.  This
-	// can end up in a broadcast/tombstone/broadcase loop. We'll attempt to
+	// can end up in a broadcast/tombstone/broadcast loop. We'll attempt to
 	// prevent that by dropping anything older than the tombstone window.
 	if newSvc.IsStale(TOMBSTONE_LIFESPAN) {
 		log.Warnf(

--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -296,6 +296,17 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 	state.Lock()
 	defer state.Unlock()
 
+	// Some weird edge cases can cause very old stuff to get broadcast.  This
+	// can end up in a broadcast/tombstone/broadcase loop. We'll attempt to
+	// prevent that by dropping anything older than the tombstone window.
+	if newSvc.IsStale(TOMBSTONE_LIFESPAN) {
+		log.Warnf(
+			"Dropping stale service received on gossip: %s:%s (%s)",
+			newSvc.Hostname, newSvc.Name, newSvc.ID,
+		)
+		return
+	}
+
 	if !state.HasServer(newSvc.Hostname) {
 		state.Servers[newSvc.Hostname] = NewServer(newSvc.Hostname)
 	}

--- a/catalog/url_listener_test.go
+++ b/catalog/url_listener_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/NinesStack/sidecar/service"
 	"github.com/relistan/go-director"
@@ -65,7 +66,7 @@ func Test_Listen(t *testing.T) {
 		hostname := "grendel"
 
 		svcId1 := "deadbeef123"
-		service1 := service.Service{ID: svcId1, Hostname: hostname}
+		service1 := service.Service{ID: svcId1, Hostname: hostname, Updated: time.Now().UTC()}
 
 		state := NewServicesState()
 		state.Hostname = hostname

--- a/service/service.go
+++ b/service/service.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/NinesStack/sidecar/output"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -63,6 +63,12 @@ func (svc *Service) IsDraining() bool {
 
 func (svc *Service) Invalidates(otherSvc *Service) bool {
 	return otherSvc != nil && svc.Updated.After(otherSvc.Updated)
+}
+
+func (svc *Service) IsStale(lifespan time.Duration) bool {
+	oldestAllowed := time.Now().UTC().Add(0 - lifespan)
+	// We add a fudge factor for clock drift
+	return svc.Updated.Before(oldestAllowed.Add(0 - 1*time.Minute))
 }
 
 func (svc *Service) Format() string {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -3,8 +3,9 @@ package service
 import (
 	"os"
 	"testing"
+	"time"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -134,6 +135,26 @@ func Test_ToService(t *testing.T) {
 			So(service.Updated, ShouldNotBeNil)
 			So(service.ProxyMode, ShouldEqual, "tcp")
 			So(service.Status, ShouldEqual, 0)
+		})
+	})
+}
+
+func Test_IsStale(t *testing.T) {
+	Convey("IsStale()", t, func() {
+		Convey("identifies records that are too old to process", func() {
+			lifespan := 1 * time.Hour
+			lastUpdated := time.Now().UTC().Add(0-lifespan).Add(0-2 * time.Minute)
+
+			svc := &Service{
+				Name:     "hrunting",
+				Updated:  lastUpdated,
+				Hostname: "beowulf",
+			}
+
+			So(svc.IsStale(lifespan), ShouldBeTrue)
+
+			svc.Updated = time.Now().UTC().Add(0-lifespan)
+			So(svc.IsStale(62*time.Minute), ShouldBeFalse)
 		})
 	})
 }


### PR DESCRIPTION
There is a longstanding bug that very, very rarely occurs, where somehow some old state gets stuck in the cluster and won't get cleared. It can also cause a gossip loop to happen where nodes are constantly talking about this old piece of state. I think this patch will prevent that from happening.