### PR TITLE
Prevent stale state from sitting around if we missed the event

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -304,6 +304,20 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 			"Dropping stale service received on gossip: %s:%s (%s)",
 			newSvc.Hostname, newSvc.Name, newSvc.ID,
 		)
+
+		// Do we somehow already have this stale thing in our state? We
+		// shouldn't. Let's clean it out if we somehow do. This seems to
+		// happen in very rare circumstances.
+		server, ok := state.Servers[newSvc.Hostname]
+		if ok && server.HasService(newSvc.ID) {
+			// Remove the service
+			delete(state.Servers[newSvc.Hostname].Services, newSvc.ID)
+
+			// If this is the last service, remove the server
+			if len(state.Servers[newSvc.Hostname].Services) < 1 {
+				delete(state.Servers, newSvc.Hostname)
+			}
+		}
 		return
 	}
 

--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -310,6 +310,11 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 		// happen in very rare circumstances.
 		server, ok := state.Servers[newSvc.Hostname]
 		if ok && server.HasService(newSvc.ID) {
+			log.Warnf(
+				"Found stale service in state, removing: %s:%s (%s)",
+				newSvc.Hostname, newSvc.Name, newSvc.ID,
+			)
+
 			// Remove the service
 			delete(state.Servers[newSvc.Hostname].Services, newSvc.ID)
 

--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -287,6 +287,26 @@ func (state *ServicesState) GetListeners() []Listener {
 	return listeners
 }
 
+// RemoveServiceEntry is intended to be called inside a lock. It removes the
+// service entry and also the server if this service was the last entry.
+func (state *ServicesState) RemoveServiceEntry(newSvc service.Service) {
+	server, ok := state.Servers[newSvc.Hostname]
+	if ok && server.HasService(newSvc.ID) {
+		log.Warnf(
+			"Found stale service in state, removing: %s:%s (%s)",
+			newSvc.Hostname, newSvc.Name, newSvc.ID,
+		)
+
+		// Remove the service
+		delete(state.Servers[newSvc.Hostname].Services, newSvc.ID)
+
+		// If this is the last service, remove the server
+		if len(state.Servers[newSvc.Hostname].Services) < 1 {
+			delete(state.Servers, newSvc.Hostname)
+		}
+	}
+}
+
 // Take a service and merge it into our state. Correctly handle
 // timestamps so we only add things newer than what we already
 // know about. Retransmits updates to cluster peers.
@@ -305,24 +325,11 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 			newSvc.Hostname, newSvc.Name, newSvc.ID,
 		)
 
+
 		// Do we somehow already have this stale thing in our state? We
 		// shouldn't. Let's clean it out if we somehow do. This seems to
 		// happen in very rare circumstances.
-		server, ok := state.Servers[newSvc.Hostname]
-		if ok && server.HasService(newSvc.ID) {
-			log.Warnf(
-				"Found stale service in state, removing: %s:%s (%s)",
-				newSvc.Hostname, newSvc.Name, newSvc.ID,
-			)
-
-			// Remove the service
-			delete(state.Servers[newSvc.Hostname].Services, newSvc.ID)
-
-			// If this is the last service, remove the server
-			if len(state.Servers[newSvc.Hostname].Services) < 1 {
-				delete(state.Servers, newSvc.Hostname)
-			}
-		}
+		state.RemoveServiceEntry(newSvc)
 		return
 	}
 
@@ -663,12 +670,7 @@ func (state *ServicesState) TombstoneOthersServices() []service.Service {
 	state.EachService(func(hostname *string, id *string, svc *service.Service) {
 		if svc.IsTombstone() &&
 			svc.Updated.Before(time.Now().UTC().Add(0-TOMBSTONE_LIFESPAN)) {
-			delete(state.Servers[*hostname].Services, *id)
-
-			// If this is the last service, remove the server
-			if len(state.Servers[*hostname].Services) < 1 {
-				delete(state.Servers, *hostname)
-			}
+			state.RemoveServiceEntry(*svc)
 		}
 
 		svcLifespan := ALIVE_LIFESPAN

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -453,7 +453,7 @@ func Test_TrackingAndBroadcasting(t *testing.T) {
 
 		Convey("Tombstones have a lifespan, then expire", func() {
 			service1.Tombstone()
-			service1.Updated = service1.Updated.Add(0 - TOMBSTONE_LIFESPAN - 1*time.Minute)
+			service1.Updated = service1.Updated.Add(0 - TOMBSTONE_LIFESPAN - 50*time.Second)
 			state.AddServiceEntry(service1)
 			state.AddServiceEntry(service2)
 			So(state.Servers[hostname].Services[service1.ID], ShouldNotBeNil)
@@ -474,6 +474,20 @@ func Test_TrackingAndBroadcasting(t *testing.T) {
 
 			So(state.Servers[hostname], ShouldNotBeNil)
 			state.TombstoneOthersServices()
+			So(state.Servers[hostname], ShouldBeNil)
+		})
+
+		Convey("When we receive a stale broadcast we remove any records we have", func() {
+			state := NewServicesState() // Totally empty
+			state.Hostname = hostname
+			state.AddServiceEntry(service1)
+			state.Servers[hostname].Services[service1.ID].Tombstone()
+			state.Servers[hostname].Services[service1.ID].Updated =
+				service1.Updated.Add(TOMBSTONE_LIFESPAN - 2*time.Minute)
+
+			So(state.Servers[hostname], ShouldNotBeNil)
+			service1.Updated = time.Unix(0, 0)
+			state.AddServiceEntry(service1)
 			So(state.Servers[hostname], ShouldBeNil)
 		})
 


### PR DESCRIPTION
In some weird edge case that rarely occurs, we can end up with some stale state that keeps getting broadcast around. This has happened maybe a dozen times in 8 years. This was a PITA because it required restarting all the nodes at once, which is potentially disruptive. This fix takes the approach that if we receive a stale update, we look to see if we also have it in our state. If we do, we drop the update on the floor *and also remove the service entry from our state*. If it were an erroneous deletion, we'll shortly get a newer update and possible re-add it. But then the decision is left up to the remote node and we don't attempt to resolve the mismatch. We had a production issue with this in progress and deploying this code fixed it.