### PR TITLE
Do real, full discovery of pods by host

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,6 @@ Defaults are in bold at the end of the line:
  * `KUBE_TIMEOUT`: How long until we time out calling the Kube API? **`3s`**
  * `CREDS_PATH`: Where do we find the token file containing API auth credentials?
    **`/var/run/secrets/kubernetes.io/serviceaccount`**
- * `ANNOUNCE_ALL_NODES`: Should we query the API and announce every node is running
-   the service? This is useful to represent the K8s cluster with a single Sidecar.
-   **`false`**
 
 ### Ports
 

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -66,7 +66,7 @@ func (k *K8sAPIDiscoverer) servicesForNode(hostname, ip string) []service.Servic
 			}
 
 			svc := service.Service{
-				ID:        k.discoveredSvcs[pod.ServiceName()].Metadata.UID,
+				ID:        "kubernetes-hosted",
 				Name:      svcName,
 				Image:     pod.Image(),
 				Created:   pod.Metadata.CreationTimestamp,

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -19,25 +19,25 @@ type K8sAPIDiscoverer struct {
 
 	Command K8sDiscoveryAdapter
 
-	discoveredSvcs   *K8sServices
+	discoveredSvcs   map[string]*K8sService
 	discoveredNodes  *K8sNodes
+	discoveredPods   map[string][]*K8sPod
 	lock             sync.RWMutex
-	announceAllNodes bool
 	hostname         string
 }
 
 // NewK8sAPIDiscoverer returns a properly configured K8sAPIDiscoverer
 func NewK8sAPIDiscoverer(kubeHost string, kubePort int, namespace string, timeout time.Duration,
-	credsPath string, announceAllNodes bool, hostname string) *K8sAPIDiscoverer {
+	credsPath string, hostname string) *K8sAPIDiscoverer {
 
 	cmd := NewKubeAPIDiscoveryCommand(kubeHost, kubePort, namespace, timeout, credsPath)
 
 	return &K8sAPIDiscoverer{
-		discoveredSvcs:   &K8sServices{},
+		discoveredSvcs:   make(map[string]*K8sService),
+		discoveredPods:   make(map[string][]*K8sPod),
 		discoveredNodes:  &K8sNodes{},
 		Namespace:        namespace,
 		Command:          cmd,
-		announceAllNodes: announceAllNodes,
 		hostname:         hostname,
 	}
 }
@@ -48,37 +48,48 @@ func NewK8sAPIDiscoverer(kubeHost string, kubePort int, namespace string, timeou
 func (k *K8sAPIDiscoverer) servicesForNode(hostname, ip string) []service.Service {
 	var services []service.Service
 
-	for _, item := range k.discoveredSvcs.Items {
-		// We require an annotation called 'ServiceName' to make sure this is
-		// a service we want to announce.
-		if item.Metadata.Labels.ServiceName == "" {
-			continue
-		}
-
-		svc := service.Service{
-			ID:        item.Metadata.UID,
-			Name:      item.Metadata.Labels.ServiceName,
-			Image:     item.Metadata.Labels.ServiceName + ":kubernetes-hosted",
-			Created:   item.Metadata.CreationTimestamp,
-			Hostname:  hostname,
-			ProxyMode: "http",
-			Status:    service.ALIVE,
-			Updated:   time.Now().UTC(),
-		}
-
-		for _, port := range item.Spec.Ports {
-			// We only support entries with NodePort defined
-			if port.NodePort < 1 {
+	for svcName, podList := range k.discoveredPods {
+		for _, pod := range podList {
+			// We require an annotation called 'ServiceName' to make sure this is
+			// a service we want to announce.
+			if pod.ServiceName() == "" {
 				continue
 			}
-			svc.Ports = append(svc.Ports, service.Port{
-				Type:        "tcp",
-				Port:        int64(port.NodePort),
-				ServicePort: int64(port.Port),
-				IP:          ip,
-			})
+
+			if pod.Spec.NodeName != hostname {
+				continue
+			}
+
+			// If we don't have a service from K8s, then there are no ports to expose
+			if k.discoveredPods[pod.ServiceName()] == nil {
+				continue
+			}
+
+			svc := service.Service{
+				ID:        k.discoveredSvcs[pod.ServiceName()].Metadata.UID,
+				Name:      svcName,
+				Image:     pod.Image(),
+				Created:   pod.Metadata.CreationTimestamp,
+				Hostname:  pod.Spec.NodeName,
+				ProxyMode: "http",
+				Status:    service.ALIVE,
+				Updated:   time.Now().UTC(),
+			}
+
+			for _, port := range k.discoveredSvcs[pod.ServiceName()].Spec.Ports {
+				// We only support entries with NodePort defined
+				if port.NodePort < 1 {
+					continue
+				}
+				svc.Ports = append(svc.Ports, service.Port{
+					Type:        "tcp",
+					Port:        int64(port.NodePort),
+					ServicePort: int64(port.Port),
+					IP:          ip,
+				})
+			}
+			services = append(services, svc)
 		}
-		services = append(services, svc)
 	}
 
 	return services
@@ -96,11 +107,6 @@ func (k *K8sAPIDiscoverer) Services() []service.Service {
 	var services []service.Service
 	for _, node := range k.discoveredNodes.Items {
 		hostname, ip := getIPHostForNode(&node)
-		if k.announceAllNodes {
-			nodeServices := k.servicesForNode(hostname, ip)
-			services = append(services, nodeServices...)
-			continue
-		}
 
 		// Don't discover all nodes, only this one. Short circuit if we found it
 		// since we'll only be in the list once.
@@ -143,17 +149,41 @@ func (k *K8sAPIDiscoverer) Listeners() []ChangeListener {
 // Run is part of the Discoverer interface and calls the Command in a loop,
 // which is injected as a Looper.
 func (k *K8sAPIDiscoverer) Run(looper director.Looper) {
+	var (
+		data []byte
+		err  error
+	)
 	looper.Loop(func() error {
-		data, err := k.getServices()
-		if err != nil {
-			log.Errorf("Failed to unmarshal services json: %s, %s", err, string(data))
-		}
+		var wg sync.WaitGroup
 
-		data, err = k.getNodes()
-		if err != nil {
-			log.Errorf("Failed to unmarshal nodes json: %s, %s", err, string(data))
-		}
+		wg.Add(1)
+		go func() {
+			data, err := k.getServices()
+			if err != nil {
+				log.Errorf("Failed to unmarshal services json: %s, %s", err, string(data))
+			}
+			wg.Done()
+		}()
 
+		wg.Add(1)
+		go func() {
+			data, err = k.getNodes()
+			if err != nil {
+				log.Errorf("Failed to unmarshal nodes json: %s, %s", err, string(data))
+			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			data, err = k.getPods()
+			if err != nil {
+				log.Errorf("Failed to unmarshal pods json: %s, %s", err, string(data))
+			}
+			wg.Done()
+		}()
+
+		wg.Wait()
 		return nil
 	})
 }
@@ -164,8 +194,17 @@ func (k *K8sAPIDiscoverer) getServices() ([]byte, error) {
 		log.Errorf("Failed to invoke K8s API discovery: %s", err)
 	}
 
+	var svcs K8sServices
+
+	err = json.Unmarshal(data, &svcs)
+	if err != nil {
+		return data, err
+	}
+
 	k.lock.Lock()
-	err = json.Unmarshal(data, &k.discoveredSvcs)
+	for _, svc := range svcs.Items {
+		k.discoveredSvcs[svc.ServiceName()] = &svc
+	}
 	k.lock.Unlock()
 	return data, err
 }
@@ -178,6 +217,27 @@ func (k *K8sAPIDiscoverer) getNodes() ([]byte, error) {
 
 	k.lock.Lock()
 	err = json.Unmarshal(data, &k.discoveredNodes)
+	k.lock.Unlock()
+	return data, err
+}
+
+func (k *K8sAPIDiscoverer) getPods() ([]byte, error) {
+	data, err := k.Command.GetPods()
+	if err != nil {
+		log.Errorf("Failed to invoke K8s API discovery: %s", err)
+	}
+
+	var pods K8sPods
+
+	err = json.Unmarshal(data, &pods)
+	if err != nil {
+		return data, err
+	}
+
+	k.lock.Lock()
+	for _, pod := range pods.Items {
+		k.discoveredPods[pod.ServiceName()] = append(k.discoveredPods[pod.ServiceName()], &pod)
+	}
 	k.lock.Unlock()
 	return data, err
 }

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -379,7 +379,7 @@ func Test_K8sServices(t *testing.T) {
 
 				So(len(services), ShouldEqual, 1)
 				svc := services[0]
-				So(svc.ID, ShouldEqual, "107b5bbf-9640-4fd0-b5de-1e898e8ae9f7")
+				So(svc.ID, ShouldEqual, "kubernetes-hosted")
 				So(svc.Name, ShouldEqual, "chopper")
 				So(svc.Image, ShouldEqual, "somewhere/chopper:54e623d")
 				So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -23,6 +23,10 @@ type mockK8sDiscoveryCommand struct {
 	GetNodesShouldError      bool
 	GetNodesShouldReturnJunk bool
 	GetNodesWasCalled        bool
+
+	GetPodsShouldError      bool
+	GetPodsShouldReturnJunk bool
+	GetPodsWasCalled        bool
 }
 
 func (m *mockK8sDiscoveryCommand) GetServices() ([]byte, error) {
@@ -128,14 +132,114 @@ func (m *mockK8sDiscoveryCommand) GetNodes() ([]byte, error) {
 	return []byte(jsonStr), nil
 }
 
+func (m *mockK8sDiscoveryCommand) GetPods() ([]byte, error) {
+	m.GetPodsWasCalled = true
+
+	if m.GetPodsShouldError {
+		return nil, errors.New("intentional test error")
+	}
+
+	if m.GetPodsShouldReturnJunk {
+		return []byte(`asdfasdf`), nil
+	}
+
+	jsonStr := `
+		{
+		   "apiVersion" : "v1",
+		   "items" : [
+		      {
+		         "metadata" : {
+	                "creationTimestamp" : "2022-11-07T13:18:03Z",
+		            "labels" : {
+		               "Environment" : "dev",
+		               "ServiceName" : "chopper"
+		            },
+		            "name" : "chopper-64fd6dcf8c-9dd66",
+		            "namespace" : "default",
+		            "resourceVersion" : "24191869",
+		            "uid" : "a9fb2fd7-8f85-4ab2-aae7-ace5b62797dc"
+		         },
+		         "spec" : {
+		            "containers" : [
+		               {
+		                  "env" : [
+		                     {
+		                        "name" : "PORT",
+		                        "value" : "4000"
+		                     }
+		                  ],
+		                  "image" : "somewhere/chopper:54e623d",
+		                  "livenessProbe" : {
+		                     "failureThreshold" : 3,
+		                     "httpGet" : {
+		                        "path" : "/health-check",
+		                        "port" : 4000,
+		                        "scheme" : "HTTP"
+		                     },
+		                     "periodSeconds" : 10,
+		                     "successThreshold" : 1,
+		                     "timeoutSeconds" : 1
+		                  },
+		                  "name" : "chopper",
+		                  "ports" : [
+		                     {
+		                        "containerPort" : 4000,
+		                        "name" : "port-0",
+		                        "protocol" : "TCP"
+		                     }
+		                  ],
+		                  "readinessProbe" : {
+		                     "failureThreshold" : 3,
+		                     "httpGet" : {
+		                        "path" : "/health-check",
+		                        "port" : 4000,
+		                        "scheme" : "HTTP"
+		                     },
+		                     "initialDelaySeconds" : 3,
+		                     "periodSeconds" : 3,
+		                     "successThreshold" : 1,
+		                     "timeoutSeconds" : 1
+		                  }
+		               }
+		            ],
+		            "dnsPolicy" : "ClusterFirst",
+		            "nodeName" : "heorot.example.com",
+		            "nodeSelector" : {
+		               "Role" : "eks-default-node-group"
+		            },
+		            "restartPolicy" : "Always",
+		            "serviceAccount" : "default",
+		            "serviceAccountName" : "default",
+		            "terminationGracePeriodSeconds" : 30
+		         },
+		         "status" : {
+		            "hostIP" : "10.0.58.178",
+		            "podIP" : "10.0.53.11",
+		            "podIPs" : [
+		               {
+		                  "ip" : "10.0.53.11"
+		               }
+		            ],
+		            "startTime" : "2023-06-23T14:58:21Z"
+		         }
+		      }
+		   ],
+		   "kind" : "PodList",
+		   "metadata" : {
+		      "resourceVersion" : "37382860"
+		   }
+		}
+	`
+	return []byte(jsonStr), nil
+}
+
 func Test_NewK8sAPIDiscoverer(t *testing.T) {
 	Convey("NewK8sAPIDiscoverer()", t, func() {
 		Convey("returns a properly configured K8sAPIDiscoverer", func() {
-			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, true, "hrothgar")
+			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
 
 			So(disco.discoveredSvcs, ShouldNotBeNil)
 			So(disco.Namespace, ShouldEqual, "heorot")
-			So(disco.announceAllNodes, ShouldBeTrue)
 			So(disco.hostname, ShouldEqual, "hrothgar")
 			So(disco.Command, ShouldNotBeNil)
 
@@ -149,7 +253,7 @@ func Test_NewK8sAPIDiscoverer(t *testing.T) {
 
 func Test_K8sHealthCheck(t *testing.T) {
 	Convey("HealthCheck() always returns 'AlwaysSuccessful'", t, func() {
-		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, true, "hrothgar")
+		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
 		check, args := disco.HealthCheck(nil)
 		So(check, ShouldEqual, "AlwaysSuccessful")
 		So(args, ShouldBeEmpty)
@@ -158,7 +262,7 @@ func Test_K8sHealthCheck(t *testing.T) {
 
 func Test_K8sListeners(t *testing.T) {
 	Convey("Listeners() always returns and empty slice", t, func() {
-		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, true, "hrothgar")
+		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
 		listeners := disco.Listeners()
 		So(listeners, ShouldBeEmpty)
 	})
@@ -166,7 +270,7 @@ func Test_K8sListeners(t *testing.T) {
 
 func Test_K8sGetServices(t *testing.T) {
 	Convey("GetServices()", t, func() {
-		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, true, "hrothgar")
+		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
 		mock := &mockK8sDiscoveryCommand{}
 		disco.Command = mock
 
@@ -181,8 +285,11 @@ func Test_K8sGetServices(t *testing.T) {
 			So(capture.String(), ShouldNotContainSubstring, "error")
 			So(disco.discoveredSvcs, ShouldNotBeNil)
 			So(disco.discoveredSvcs, ShouldNotEqual, &K8sServices{})
-			So(len(disco.discoveredSvcs.Items), ShouldEqual, 1)
-			So(len(disco.discoveredSvcs.Items[0].Spec.Ports), ShouldEqual, 2)
+			So(len(disco.discoveredSvcs), ShouldEqual, 1)
+			// Cheating, there is only one, but this gets it
+			for _, svc := range disco.discoveredSvcs {
+				So(len(svc.Spec.Ports), ShouldEqual, 2)
+			}
 		})
 
 		Convey("call the command and logs errors", func() {
@@ -209,7 +316,7 @@ func Test_K8sGetServices(t *testing.T) {
 
 func Test_K8sGetNodes(t *testing.T) {
 	Convey("GetNodes()", t, func() {
-		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, true, "hrothgar")
+		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
 		mock := &mockK8sDiscoveryCommand{}
 		disco.Command = mock
 
@@ -255,55 +362,93 @@ func Test_K8sServices(t *testing.T) {
 		mock := &mockK8sDiscoveryCommand{}
 
 		Convey("works on a newly-created Discoverer", func() {
-			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, true, "hrothgar")
+			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
 			disco.Command = mock
 
 			services := disco.Services()
 			So(len(services), ShouldEqual, 0)
 		})
 
-		Convey("when discovering for all nodes", func() {
-			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, true, "hrothgar")
-			disco.Command = mock
+		Convey("when discovering for a node where services are running", func() {
+			Convey("one service is discovered", func() {
+				disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "heorot.example.com")
+				disco.Command = mock
 
-			Convey("returns the list of cached services", func() {
 				disco.Run(director.NewFreeLooper(director.ONCE, nil))
 				services := disco.Services()
 
-				So(len(services), ShouldEqual, 2)
+				So(len(services), ShouldEqual, 1)
 				svc := services[0]
 				So(svc.ID, ShouldEqual, "107b5bbf-9640-4fd0-b5de-1e898e8ae9f7")
 				So(svc.Name, ShouldEqual, "chopper")
-				So(svc.Image, ShouldEqual, "chopper:kubernetes-hosted")
+				So(svc.Image, ShouldEqual, "somewhere/chopper:54e623d")
 				So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")
-				So(svc.Hostname, ShouldEqual, "beowulf.example.com")
+				So(svc.Hostname, ShouldEqual, "heorot.example.com")
 				So(svc.ProxyMode, ShouldEqual, "http")
 				So(svc.Status, ShouldEqual, service.ALIVE)
 				So(svc.Updated.Unix(), ShouldBeGreaterThan, time.Now().UTC().Add(-2*time.Second).Unix())
 				So(len(svc.Ports), ShouldEqual, 1)
-				So(svc.Ports[0].IP, ShouldEqual, "10.100.69.136")
+				So(svc.Ports[0].IP, ShouldEqual, "10.100.69.147")
 			})
 		})
 
-		Convey("when discovering for only this node", func() {
-			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, false, "heorot.example.com")
-			disco.Command = mock
+		Convey("when discovering for a node without any services", func() {
+			Convey("there are no services discovered", func() {
+				disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "beowulf", 3*time.Second, credsPath, "beowulf.example.com")
+				disco.Command = mock
 
+				disco.Run(director.NewFreeLooper(director.ONCE, nil))
+				services := disco.Services()
+
+				So(len(services), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func Test_K8sGetPods(t *testing.T) {
+	Convey("GetPods()", t, func() {
+		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+		mock := &mockK8sDiscoveryCommand{}
+		disco.Command = mock
+
+		capture := &bytes.Buffer{}
+
+		Convey("calls the command and unmarshals the result", func() {
+			log.SetOutput(capture)
 			disco.Run(director.NewFreeLooper(director.ONCE, nil))
-			services := disco.Services()
+			log.SetOutput(os.Stdout)
 
-			So(len(services), ShouldEqual, 1)
-			svc := services[0]
-			So(svc.ID, ShouldEqual, "107b5bbf-9640-4fd0-b5de-1e898e8ae9f7")
-			So(svc.Name, ShouldEqual, "chopper")
-			So(svc.Image, ShouldEqual, "chopper:kubernetes-hosted")
-			So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")
-			So(svc.Hostname, ShouldEqual, "heorot.example.com")
-			So(svc.ProxyMode, ShouldEqual, "http")
-			So(svc.Status, ShouldEqual, service.ALIVE)
-			So(svc.Updated.Unix(), ShouldBeGreaterThan, time.Now().UTC().Add(-2*time.Second).Unix())
-			So(len(svc.Ports), ShouldEqual, 1)
-			So(svc.Ports[0].IP, ShouldEqual, "10.100.69.147")
+			So(mock.GetPodsWasCalled, ShouldBeTrue)
+			So(capture.String(), ShouldNotContainSubstring, "error")
+			So(disco.discoveredPods, ShouldNotBeNil)
+			So(disco.discoveredPods, ShouldNotEqual, &K8sPods{})
+			So(len(disco.discoveredPods), ShouldEqual, 1)
+
+			pods := disco.discoveredPods["chopper"]
+			So(pods, ShouldNotBeEmpty)
+			pod := pods[0]
+			So(pod.ServiceName(), ShouldEqual, "chopper")
+		})
+
+		Convey("call the command and logs errors", func() {
+			mock.GetPodsShouldError = true
+			log.SetOutput(capture)
+			disco.Run(director.NewFreeLooper(director.ONCE, nil))
+			log.SetOutput(os.Stdout)
+
+			So(mock.GetPodsWasCalled, ShouldBeTrue)
+			So(capture.String(), ShouldContainSubstring, "Failed to invoke")
+		})
+
+		Convey("call the command and logs errors from the JSON output", func() {
+			mock.GetPodsShouldReturnJunk = true
+			log.SetOutput(capture)
+			disco.Run(director.NewFreeLooper(director.ONCE, nil))
+			log.SetOutput(os.Stdout)
+
+			So(mock.GetPodsWasCalled, ShouldBeTrue)
+			So(capture.String(), ShouldContainSubstring, "Failed to unmarshal pods json")
 		})
 	})
 }

--- a/discovery/kubernetes_support.go
+++ b/discovery/kubernetes_support.go
@@ -16,55 +16,63 @@ import (
 
 // K8sServices represents the payload that is returned by `kubectl get services -o json`
 type K8sServices struct {
-	APIVersion string `json:"apiVersion"`
-	Items      []struct {
-		APIVersion string `json:"apiVersion"`
-		Kind       string `json:"kind"`
-		Metadata   struct {
-			Annotations struct {
-				KubectlKubernetesIoLastAppliedConfiguration string `json:"kubectl.kubernetes.io/last-applied-configuration"`
-			} `json:"annotations"`
-			CreationTimestamp time.Time `json:"creationTimestamp"`
-			Labels            struct {
-				Environment string `json:"Environment"`
-				ServiceName string `json:"ServiceName"`
-			} `json:"labels"`
-			Name            string `json:"name"`
-			Namespace       string `json:"namespace"`
-			ResourceVersion string `json:"resourceVersion"`
-			UID             string `json:"uid"`
-		} `json:"metadata"`
-		Spec struct {
-			ClusterIP             string   `json:"clusterIP"`
-			ClusterIPs            []string `json:"clusterIPs"`
-			InternalTrafficPolicy string   `json:"internalTrafficPolicy"`
-			IPFamilies            []string `json:"ipFamilies"`
-			IPFamilyPolicy        string   `json:"ipFamilyPolicy"`
-			Ports                 []struct {
-				Port       int    `json:"port"`
-				Protocol   string `json:"protocol"`
-				// This field mutates types when served from the K8s API. This is bad
-				// API design, and means this won't parse with Go's stdlib JSON support.
-				// Commenting out so that this reason is clear.
-				// TargetPort int    `json:"targetPort"`
-				NodePort   int    `json:"nodePort"`
-			} `json:"ports"`
-			Selector struct {
-				Environment string `json:"Environment"`
-				ServiceName string `json:"ServiceName"`
-			} `json:"selector"`
-			SessionAffinity string `json:"sessionAffinity"`
-			Type            string `json:"type"`
-		} `json:"spec"`
-		Status struct {
-			LoadBalancer struct {
-			} `json:"loadBalancer"`
-		} `json:"status"`
-	} `json:"items"`
-	Kind     string `json:"kind"`
-	Metadata struct {
+	APIVersion string       `json:"apiVersion"`
+	Items      []K8sService `json:"items"`
+	Kind       string       `json:"kind"`
+	Metadata   struct {
 		ResourceVersion string `json:"resourceVersion"`
 	} `json:"metadata"`
+}
+
+// A K8sService represents a single service from the K8sServices response
+type K8sService struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Annotations struct {
+			KubectlKubernetesIoLastAppliedConfiguration string `json:"kubectl.kubernetes.io/last-applied-configuration"`
+		} `json:"annotations"`
+		CreationTimestamp time.Time `json:"creationTimestamp"`
+		Labels            struct {
+			Environment string `json:"Environment"`
+			ServiceName string `json:"ServiceName"`
+		} `json:"labels"`
+		Name            string `json:"name"`
+		Namespace       string `json:"namespace"`
+		ResourceVersion string `json:"resourceVersion"`
+		UID             string `json:"uid"`
+	} `json:"metadata"`
+	Spec struct {
+		ClusterIP             string   `json:"clusterIP"`
+		ClusterIPs            []string `json:"clusterIPs"`
+		InternalTrafficPolicy string   `json:"internalTrafficPolicy"`
+		IPFamilies            []string `json:"ipFamilies"`
+		IPFamilyPolicy        string   `json:"ipFamilyPolicy"`
+		Ports                 []struct {
+			Port     int    `json:"port"`
+			Protocol string `json:"protocol"`
+			// This field mutates types when served from the K8s API. This is bad
+			// API design, and means this won't parse with Go's stdlib JSON support.
+			// Commenting out so that this reason is clear.
+			// TargetPort int    `json:"targetPort"`
+			NodePort int `json:"nodePort"`
+		} `json:"ports"`
+		Selector struct {
+			Environment string `json:"Environment"`
+			ServiceName string `json:"ServiceName"`
+		} `json:"selector"`
+		SessionAffinity string `json:"sessionAffinity"`
+		Type            string `json:"type"`
+	} `json:"spec"`
+	Status struct {
+		LoadBalancer struct {
+		} `json:"loadBalancer"`
+	} `json:"status"`
+}
+
+// ServiceName extracts and returns the service name
+func (svc *K8sService) ServiceName() string {
+	return svc.Metadata.Labels.ServiceName
 }
 
 // K8sServices represents a cut-down version of the payload that is returned by
@@ -83,11 +91,105 @@ type K8sNode struct {
 	Status struct {
 		Addresses []K8sNodeAddress `json:"addresses"`
 	} `json:"status"`
+	Metadata struct {
+		Name string `json:"name"`
+	} `json:"metadata"`
 }
 
 type K8sNodeAddress struct {
 	Address string `json:"address"`
 	Type    string `json:"type"`
+}
+
+// A K8sPods is what the API returns for a list of pods. We parse out the
+// fields that we care about.
+type K8sPods struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+	Metadata   struct {
+		ResourceVersion string `json:"resourceVersion"`
+	} `json:"metadata"`
+	Items []K8sPod `json:"items"`
+}
+
+// A K8sPod is an API response representing a single Pod
+type K8sPod struct {
+	Metadata struct {
+		Name              string    `json:"name"`
+		Namespace         string    `json:"namespace"`
+		CreationTimestamp time.Time `json:"creationTimestamp"`
+		Labels            struct {
+			Environment string `json:"Environment"`
+			ServiceName string `json:"ServiceName"`
+			App         string `json:"app"`
+			Release     string `json:"Release"`
+		} `json:"labels"`
+	} `json:"metadata"`
+	Spec struct {
+		Containers []struct {
+			Name  string `json:"name"`
+			Image string `json:"image"`
+			Ports []struct {
+				Name          string `json:"name"`
+				ContainerPort int    `json:"containerPort"`
+				Protocol      string `json:"protocol"`
+			} `json:"ports,omitempty"`
+		} `json:"containers"`
+		NodeName string `json:"nodeName"`
+	} `json:"spec"`
+	Status struct {
+		Phase      string `json:"phase"`
+		Conditions []struct {
+			Type               string      `json:"type"`
+			Status             string      `json:"status"`
+			LastProbeTime      interface{} `json:"lastProbeTime"`
+			LastTransitionTime time.Time   `json:"lastTransitionTime"`
+		} `json:"conditions"`
+		HostIP string `json:"hostIP"`
+		PodIP  string `json:"podIP"`
+		PodIPs []struct {
+			IP string `json:"ip"`
+		} `json:"podIPs"`
+		StartTime         time.Time               `json:"startTime"`
+		ContainerStatuses []K8sPodContainerStatus `json:"containerStatuses"`
+	} `json:"status"`
+}
+
+func (p *K8sPod) ServiceName() string {
+	return p.Metadata.Labels.ServiceName
+}
+
+func (p *K8sPod) Image() string {
+	if len(p.Spec.Containers) < 1 {
+		return ""
+	}
+
+	// In theory the first one should be the main container image. There is no
+	// other real way to tell if a side car container is running in the pod.
+	return p.Spec.Containers[0].Image
+}
+
+type K8sPodContainerStatus struct {
+	Name  string `json:"name"`
+	State struct {
+		Running struct {
+			StartedAt time.Time `json:"startedAt"`
+		} `json:"running"`
+		Terminated struct {
+			ExitCode    int       `json:"exitCode"`
+			Reason      string    `json:"reason"`
+			StartedAt   time.Time `json:"startedAt"`
+			FinishedAt  time.Time `json:"finishedAt"`
+			ContainerID string    `json:"containerID"`
+		} `json:"terminated"`
+	} `json:"state"`
+	LastState struct {
+	} `json:"lastState"`
+	Ready        bool   `json:"ready"`
+	RestartCount int    `json:"restartCount"`
+	Image        string `json:"image"`
+	ImageID      string `json:"imageID"`
+	ContainerID  string `json:"containerID"`
 }
 
 // A K8sDiscoveryAdapter wraps a call to an external command that can be used
@@ -96,6 +198,7 @@ type K8sNodeAddress struct {
 type K8sDiscoveryAdapter interface {
 	GetServices() ([]byte, error)
 	GetNodes() ([]byte, error)
+	GetPods() ([]byte, error)
 }
 
 // KubeAPIDiscoveryCommand is the main implementation for K8sDiscoveryCommand
@@ -200,4 +303,9 @@ func (d *KubeAPIDiscoveryCommand) GetServices() ([]byte, error) {
 
 func (d *KubeAPIDiscoveryCommand) GetNodes() ([]byte, error) {
 	return d.makeRequest("/api/v1/nodes/")
+}
+
+func (d *KubeAPIDiscoveryCommand) GetPods() ([]byte, error) {
+	return d.makeRequest("/api/v1/namespaces/" + d.Namespace + "/pods?limit=10000")
+
 }


### PR DESCRIPTION
This finally goes the last step, and pulls all the pod info from the API. If Sidecar runs as a DaemonSet, this allows it to discover and announce for each node, using the API as the reference. This could end up with a lot of API calls if it were to run on many tens of nodes. For now, for our use case (the only people running it, I think), this should work fine.