### PR TITLE
Need a unique ID, use UID again

### DIFF
--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -66,7 +66,7 @@ func (k *K8sAPIDiscoverer) servicesForNode(hostname, ip string) []service.Servic
 			}
 
 			svc := service.Service{
-				ID:        "kubernetes-hosted",
+				ID:        pod.Metadata.UID,
 				Name:      svcName,
 				Image:     pod.Image(),
 				Created:   pod.Metadata.CreationTimestamp,

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -379,7 +379,8 @@ func Test_K8sServices(t *testing.T) {
 
 				So(len(services), ShouldEqual, 1)
 				svc := services[0]
-				So(svc.ID, ShouldEqual, "kubernetes-hosted")
+				// ID is the Pod UID
+				So(svc.ID, ShouldEqual, "a9fb2fd7-8f85-4ab2-aae7-ace5b62797dc")
 				So(svc.Name, ShouldEqual, "chopper")
 				So(svc.Image, ShouldEqual, "somewhere/chopper:54e623d")
 				So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")

--- a/discovery/kubernetes_support.go
+++ b/discovery/kubernetes_support.go
@@ -124,6 +124,7 @@ type K8sPod struct {
 			App         string `json:"app"`
 			Release     string `json:"Release"`
 		} `json:"labels"`
+		UID             string `json:"uid"`
 	} `json:"metadata"`
 	Spec struct {
 		Containers []struct {


### PR DESCRIPTION
K8s-hosted services were stamping on each other because hostname + ID is used as a unique identifier. This reverts to using the K8s Pod UID as the ID. They are detectable vs Mesos IDs because they are UUIDs and contain dashes.