### PR TITLE
Lots of fixes for K8s API support

### DIFF
--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -87,17 +87,21 @@ func (k *K8sAPIDiscoverer) serviceFromPod(svcName, ip string, pod K8sPod) servic
 		Updated:   time.Now().UTC(),
 	}
 
-	for _, port := range k.discoveredSvcs[pod.ServiceName()].Spec.Ports {
-		// We only support entries with NodePort defined
-		if port.NodePort < 1 {
-			continue
+	if discovered, ok := k.discoveredSvcs[pod.ServiceName()]; ok {
+		if discovered.Spec.Ports != nil {
+			for _, port := range discovered.Spec.Ports {
+				// We only support entries with NodePort defined
+				if port.NodePort < 1 {
+					continue
+				}
+				svc.Ports = append(svc.Ports, service.Port{
+					Type:        "tcp",
+					Port:        int64(port.NodePort),
+					ServicePort: int64(port.Port),
+					IP:          ip,
+				})
+			}
 		}
-		svc.Ports = append(svc.Ports, service.Port{
-			Type:        "tcp",
-			Port:        int64(port.NodePort),
-			ServicePort: int64(port.Port),
-			IP:          ip,
-		})
 	}
 	return svc
 }

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -247,7 +247,13 @@ func (k *K8sAPIDiscoverer) getPods() ([]byte, error) {
 	for _, pod := range pods.Items {
 		// Avoid Go for loop pointer gotcha (will be fixed in Go 1.22)
 		thisPod := pod
-		k.discoveredPods[pod.ServiceName()] = append(k.discoveredPods[pod.ServiceName()], &thisPod)
+
+		// We only care about things with a ServiceName defined
+		if len(pod.ServiceName()) > 0 {
+			k.discoveredPods[pod.ServiceName()] = append(k.discoveredPods[pod.ServiceName()], &thisPod)
+		} else {
+			log.Infof("Skipping pod %s: missing ServiceName label", pod.Metadata.UID)
+		}
 	}
 	k.lock.Unlock()
 	return data, err

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -256,7 +256,7 @@ func (k *K8sAPIDiscoverer) getPods() ([]byte, error) {
 		if len(pod.ServiceName()) > 0 {
 			k.discoveredPods[pod.ServiceName()] = append(k.discoveredPods[pod.ServiceName()], &thisPod)
 		} else {
-			log.Infof("Skipping pod %s: missing ServiceName label", pod.Metadata.UID)
+			log.Debugf("Skipping pod %s: missing ServiceName label", pod.Metadata.UID)
 		}
 	}
 	k.lock.Unlock()

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -253,11 +253,18 @@ func (k *K8sAPIDiscoverer) getPods() ([]byte, error) {
 		thisPod := pod
 
 		// We only care about things with a ServiceName defined
-		if len(pod.ServiceName()) > 0 {
-			k.discoveredPods[pod.ServiceName()] = append(k.discoveredPods[pod.ServiceName()], &thisPod)
-		} else {
+		if len(pod.ServiceName()) < 1 {
 			log.Debugf("Skipping pod %s: missing ServiceName label", pod.Metadata.UID)
+			continue
 		}
+
+		// Enables explicit skipping of some services via a Label
+		if pod.Metadata.Labels.SidecarDiscover == "false" {
+			continue
+		}
+
+		k.discoveredPods[pod.ServiceName()] = append(k.discoveredPods[pod.ServiceName()], &thisPod)
+
 	}
 	k.lock.Unlock()
 	return data, err

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -10,6 +10,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var DefaultK8sLoopInterval = 5 * time.Second
+
 // A K8sAPIDiscoverer is a discovery mechanism that assumes that a K8s cluster
 // with be fronted by a load balancer and that all the ports exposed will match
 // up on both the load balancer and the backing pods. It relies on an underlying
@@ -24,6 +26,7 @@ type K8sAPIDiscoverer struct {
 	discoveredPods  map[string][]*K8sPod
 	lock            sync.RWMutex
 	hostname        string
+	loopInterval    time.Duration
 }
 
 // NewK8sAPIDiscoverer returns a properly configured K8sAPIDiscoverer
@@ -39,6 +42,7 @@ func NewK8sAPIDiscoverer(kubeHost string, kubePort int, namespace string, timeou
 		Namespace:       namespace,
 		Command:         cmd,
 		hostname:        hostname,
+		loopInterval:    DefaultK8sLoopInterval,
 	}
 }
 
@@ -191,6 +195,12 @@ func (k *K8sAPIDiscoverer) Run(looper director.Looper) {
 			if err != nil {
 				log.Errorf("Failed to unmarshal pods json: %s, %s", err, string(data))
 			}
+			wg.Done()
+		}()
+
+		wg.Add(1)
+		go func() {
+			time.Sleep(k.loopInterval)
 			wg.Done()
 		}()
 

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -357,6 +357,7 @@ func Test_NewK8sAPIDiscoverer(t *testing.T) {
 	Convey("NewK8sAPIDiscoverer()", t, func() {
 		Convey("returns a properly configured K8sAPIDiscoverer", func() {
 			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+			disco.loopInterval = time.Duration(0)
 
 			So(disco.discoveredSvcs, ShouldNotBeNil)
 			So(disco.Namespace, ShouldEqual, "heorot")
@@ -374,6 +375,7 @@ func Test_NewK8sAPIDiscoverer(t *testing.T) {
 func Test_K8sHealthCheck(t *testing.T) {
 	Convey("HealthCheck() always returns 'AlwaysSuccessful'", t, func() {
 		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+		disco.loopInterval = time.Duration(0)
 		check, args := disco.HealthCheck(nil)
 		So(check, ShouldEqual, "AlwaysSuccessful")
 		So(args, ShouldBeEmpty)
@@ -383,6 +385,7 @@ func Test_K8sHealthCheck(t *testing.T) {
 func Test_K8sListeners(t *testing.T) {
 	Convey("Listeners() always returns and empty slice", t, func() {
 		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+		disco.loopInterval = time.Duration(0)
 		listeners := disco.Listeners()
 		So(listeners, ShouldBeEmpty)
 	})
@@ -391,6 +394,7 @@ func Test_K8sListeners(t *testing.T) {
 func Test_K8sGetServices(t *testing.T) {
 	Convey("GetServices()", t, func() {
 		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+		disco.loopInterval = time.Duration(0)
 		mock := &mockK8sDiscoveryCommand{}
 		disco.Command = mock
 
@@ -437,6 +441,7 @@ func Test_K8sGetServices(t *testing.T) {
 func Test_K8sGetNodes(t *testing.T) {
 	Convey("GetNodes()", t, func() {
 		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+		disco.loopInterval = time.Duration(0)
 		mock := &mockK8sDiscoveryCommand{}
 		disco.Command = mock
 
@@ -483,6 +488,7 @@ func Test_K8sServices(t *testing.T) {
 
 		Convey("works on a newly-created Discoverer", func() {
 			disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+			disco.loopInterval = time.Duration(0)
 			disco.Command = mock
 
 			services := disco.Services()
@@ -492,6 +498,7 @@ func Test_K8sServices(t *testing.T) {
 		Convey("when discovering for a node where services are running", func() {
 			Convey("two services are discovered", func() {
 				disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "heorot.example.com")
+				disco.loopInterval = time.Duration(0)
 				disco.Command = mock
 
 				disco.Run(director.NewFreeLooper(director.ONCE, nil))
@@ -535,6 +542,7 @@ func Test_K8sServices(t *testing.T) {
 		Convey("when discovering for a node without any services", func() {
 			Convey("there are no services discovered", func() {
 				disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "beowulf", 3*time.Second, credsPath, "beowulf.example.com")
+				disco.loopInterval = time.Duration(0)
 				disco.Command = mock
 
 				disco.Run(director.NewFreeLooper(director.ONCE, nil))
@@ -549,6 +557,7 @@ func Test_K8sServices(t *testing.T) {
 func Test_K8sGetPods(t *testing.T) {
 	Convey("GetPods()", t, func() {
 		disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "hrothgar")
+		disco.loopInterval = time.Duration(0)
 		mock := &mockK8sDiscoveryCommand{}
 		disco.Command = mock
 

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -324,6 +324,14 @@ func (m *mockK8sDiscoveryCommand) GetPods() ([]byte, error) {
 		            ],
 		            "startTime" : "2023-06-23T14:58:21Z"
 		         }
+		      },
+		      {
+		         "metadata" : {
+		            "labels" : {
+						"IntentionallyBroken": "yes"
+					},
+		            "uid" : "deadbeef-8f85-4ab2-aae7-ace5b62797dc"
+		         }
 		      }
 		   ],
 		   "kind" : "PodList",
@@ -551,6 +559,14 @@ func Test_K8sGetPods(t *testing.T) {
 			So(pods, ShouldNotBeEmpty)
 			pod := pods[0]
 			So(pod.ServiceName(), ShouldEqual, "chopper")
+		})
+
+		Convey("skips pods that are missing ServiceName", func() {
+			log.SetOutput(capture)
+			disco.Run(director.NewFreeLooper(director.ONCE, nil))
+			log.SetOutput(os.Stdout)
+
+			So(capture.String(), ShouldContainSubstring, "Skipping pod deadbeef")
 		})
 
 		Convey("call the command and logs errors", func() {

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -563,8 +563,10 @@ func Test_K8sGetPods(t *testing.T) {
 
 		Convey("skips pods that are missing ServiceName", func() {
 			log.SetOutput(capture)
+			log.SetLevel(log.DebugLevel)
 			disco.Run(director.NewFreeLooper(director.ONCE, nil))
 			log.SetOutput(os.Stdout)
+			log.SetLevel(log.InfoLevel)
 
 			So(capture.String(), ShouldContainSubstring, "Skipping pod deadbeef")
 		})

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -332,6 +332,16 @@ func (m *mockK8sDiscoveryCommand) GetPods() ([]byte, error) {
 					},
 		            "uid" : "deadbeef-8f85-4ab2-aae7-ace5b62797dc"
 		         }
+		      },
+		      {
+		         "metadata" : {
+		            "labels" : {
+						"ServiceName": "grendel",
+						"IntentionallyBroken": "yes",
+						"SidecarDiscover": "false"
+					},
+		            "uid" : "feedbeef-8f85-4ab2-aae7-ace5b62797dc"
+		         }
 		      }
 		   ],
 		   "kind" : "PodList",

--- a/discovery/kubernetes_support.go
+++ b/discovery/kubernetes_support.go
@@ -119,12 +119,13 @@ type K8sPod struct {
 		Namespace         string    `json:"namespace"`
 		CreationTimestamp time.Time `json:"creationTimestamp"`
 		Labels            struct {
-			Environment string `json:"Environment"`
-			ServiceName string `json:"ServiceName"`
-			App         string `json:"app"`
-			Release     string `json:"Release"`
+			Environment     string `json:"Environment"`
+			ServiceName     string `json:"ServiceName"`
+			App             string `json:"app"`
+			Release         string `json:"Release"`
+			SidecarDiscover string `json:"SidecarDiscover"`
 		} `json:"labels"`
-		UID             string `json:"uid"`
+		UID string `json:"uid"`
 	} `json:"metadata"`
 	Spec struct {
 		Containers []struct {


### PR DESCRIPTION
Reduce CPU and memory, don't launch large number of goroutines. Filter for `ServiceName` and anything not labeled `SidecarDiscover: false`