### PR TITLE
Support ProxyMode label on K8s

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -325,7 +325,6 @@ func (state *ServicesState) AddServiceEntry(newSvc service.Service) {
 			newSvc.Hostname, newSvc.Name, newSvc.ID,
 		)
 
-
 		// Do we somehow already have this stale thing in our state? We
 		// shouldn't. Let's clean it out if we somehow do. This seems to
 		// happen in very rare circumstances.

--- a/catalog/view.go
+++ b/catalog/view.go
@@ -33,7 +33,8 @@ func (state *ServicesState) EachLocalService(fn func(hostname *string, serviceId
 }
 
 // Services -------------------------------
-//   by Age
+//
+//	by Age
 type ServicesByAge []*service.Service
 
 func (s ServicesByAge) Len() int           { return len(s) }
@@ -52,7 +53,7 @@ func (s *Server) SortedServices() []*service.Service {
 	return servicesList
 }
 
-//   by Name
+// by Name
 type ServicesByName []*service.Service
 
 func (a ServicesByName) Len() int           { return len(a) }
@@ -87,7 +88,8 @@ func (state *ServicesState) SortedServers() []*Server {
 }
 
 // Memberlist --------------------------------
-//   by Name
+//
+//	by Name
 type ListByName []*memberlist.Node
 
 func (a ListByName) Len() int           { return len(a) }

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -91,6 +91,11 @@ func (k *K8sAPIDiscoverer) serviceFromPod(svcName, ip string, pod K8sPod) servic
 		Updated:   time.Now().UTC(),
 	}
 
+	// It's possible to override the default with a ProxyMode label
+	if pod.Metadata.Labels.ProxyMode == "tcp" {
+		svc.ProxyMode = "tcp"
+	}
+
 	if discovered, ok := k.discoveredSvcs[pod.ServiceName()]; ok {
 		if discovered.Spec.Ports != nil {
 			for _, port := range discovered.Spec.Ports {

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -254,7 +255,8 @@ func (m *mockK8sDiscoveryCommand) GetPods() ([]byte, error) {
 	                "creationTimestamp" : "2022-11-07T13:18:03Z",
 		            "labels" : {
 		               "Environment" : "dev",
-		               "ServiceName" : "chopper"
+		               "ServiceName" : "chopper",
+                       "ProxyMode"   : "tcp"
 		            },
 		            "name" : "chopper-64fd6dcf8c-9dd66",
 		            "namespace" : "default",
@@ -503,32 +505,18 @@ func Test_K8sServices(t *testing.T) {
 
 				disco.Run(director.NewFreeLooper(director.ONCE, nil))
 				services := disco.Services()
+				// Sort for stable lists
+				sort.Sort(service.ByID(services))
 
 				So(len(services), ShouldEqual, 2)
 
 				svc := services[0]
-				// ID is the Pod UID
-				So(svc.ID, ShouldEqual, "abbacafe-8f85-4ab2-aae7-ace5b62797dc")
-				So(svc.Name, ShouldEqual, "arthur")
-				So(svc.Image, ShouldEqual, "somewhere/arthur:54e623d")
-				So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")
-				So(svc.Hostname, ShouldEqual, "heorot.example.com")
-				So(svc.ProxyMode, ShouldEqual, "http")
-				So(svc.Status, ShouldEqual, service.ALIVE)
-				So(svc.Updated.Unix(), ShouldBeGreaterThan, time.Now().UTC().Add(-2*time.Second).Unix())
-				So(len(svc.Ports), ShouldEqual, 1)
-				So(svc.Ports[0].IP, ShouldEqual, "10.100.69.147")
-				So(svc.Ports[0].Port, ShouldEqual, 38089)
-				So(svc.Ports[0].ServicePort, ShouldEqual, 10009)
-
-				svc = services[1]
 				// ID is the Pod UID
 				So(svc.ID, ShouldEqual, "a9fb2fd7-8f85-4ab2-aae7-ace5b62797dc")
 				So(svc.Name, ShouldEqual, "chopper")
 				So(svc.Image, ShouldEqual, "somewhere/chopper:54e623d")
 				So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")
 				So(svc.Hostname, ShouldEqual, "heorot.example.com")
-				So(svc.ProxyMode, ShouldEqual, "http")
 				So(svc.Status, ShouldEqual, service.ALIVE)
 				So(svc.Updated.Unix(), ShouldBeGreaterThan, time.Now().UTC().Add(-2*time.Second).Unix())
 				So(len(svc.Ports), ShouldEqual, 1)
@@ -536,6 +524,39 @@ func Test_K8sServices(t *testing.T) {
 				So(svc.Ports[0].ServicePort, ShouldEqual, 10007)
 				So(svc.Ports[0].Port, ShouldEqual, 38088)
 
+				svc = services[1]
+				// ID is the Pod UID
+				So(svc.ID, ShouldEqual, "abbacafe-8f85-4ab2-aae7-ace5b62797dc")
+				So(svc.Name, ShouldEqual, "arthur")
+				So(svc.Image, ShouldEqual, "somewhere/arthur:54e623d")
+				So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")
+				So(svc.Hostname, ShouldEqual, "heorot.example.com")
+				So(svc.Status, ShouldEqual, service.ALIVE)
+				So(svc.Updated.Unix(), ShouldBeGreaterThan, time.Now().UTC().Add(-2*time.Second).Unix())
+				So(len(svc.Ports), ShouldEqual, 1)
+				So(svc.Ports[0].IP, ShouldEqual, "10.100.69.147")
+				So(svc.Ports[0].Port, ShouldEqual, 38089)
+				So(svc.Ports[0].ServicePort, ShouldEqual, 10009)
+
+			})
+
+			Convey("The ProxyMode label switches the proxy mode", func() {
+				disco := NewK8sAPIDiscoverer("127.0.0.1", 443, "heorot", 3*time.Second, credsPath, "heorot.example.com")
+				disco.loopInterval = time.Duration(0)
+				disco.Command = mock
+
+				disco.Run(director.NewFreeLooper(director.ONCE, nil))
+				services := disco.Services()
+				// Sort for stable lists
+				sort.Sort(service.ByID(services))
+
+				svc := services[0]
+				So(svc.ID, ShouldEqual, "a9fb2fd7-8f85-4ab2-aae7-ace5b62797dc")
+				So(svc.ProxyMode, ShouldEqual, "tcp")
+
+				svc = services[1]
+				So(svc.ID, ShouldEqual, "abbacafe-8f85-4ab2-aae7-ace5b62797dc")
+				So(svc.ProxyMode, ShouldEqual, "http")
 			})
 		})
 

--- a/discovery/kubernetes_support.go
+++ b/discovery/kubernetes_support.go
@@ -124,6 +124,7 @@ type K8sPod struct {
 			App             string `json:"app"`
 			Release         string `json:"Release"`
 			SidecarDiscover string `json:"SidecarDiscover"`
+			ProxyMode       string `json:"ProxyMode"`
 		} `json:"labels"`
 		UID string `json:"uid"`
 	} `json:"metadata"`

--- a/receiver/receiver_test.go
+++ b/receiver/receiver_test.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/NinesStack/sidecar/catalog"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/jarcoal/httpmock.v1"
-	"github.com/NinesStack/sidecar/catalog"
 )
 
 func Test_FetchState(t *testing.T) {

--- a/service/service.go
+++ b/service/service.go
@@ -208,3 +208,9 @@ func buildPortFor(port *docker.APIPort, container *docker.APIContainers, ip stri
 
 	return returnPort
 }
+
+type ByID []Service
+
+func (a ByID) Len() int           { return len(a) }
+func (a ByID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByID) Less(i, j int) bool { return strings.Compare(a[i].ID, a[j].ID) == -1 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -143,7 +143,7 @@ func Test_IsStale(t *testing.T) {
 	Convey("IsStale()", t, func() {
 		Convey("identifies records that are too old to process", func() {
 			lifespan := 1 * time.Hour
-			lastUpdated := time.Now().UTC().Add(0-lifespan).Add(0-2 * time.Minute)
+			lastUpdated := time.Now().UTC().Add(0 - lifespan).Add(0 - 2*time.Minute)
 
 			svc := &Service{
 				Name:     "hrunting",
@@ -153,7 +153,7 @@ func Test_IsStale(t *testing.T) {
 
 			So(svc.IsStale(lifespan), ShouldBeTrue)
 
-			svc.Updated = time.Now().UTC().Add(0-lifespan)
+			svc.Updated = time.Now().UTC().Add(0 - lifespan)
 			So(svc.IsStale(62*time.Minute), ShouldBeFalse)
 		})
 	})


### PR DESCRIPTION
This uses a `ProxyMode` label in K8s the same way that we use the Docker label.

Additional changes are just from a `go fmt ./...`