### PR TITLE
[k8s] Add ws proxy mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ release: #: Build and upload the release to GitHub
 clean: #: Clean up build artifacts
 clean:
 	$(RM) ./$(APP_NAME)
-	$(RM) ./docker/$(APP_NAME)
 
 ### Test
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ code-check:
 build: #: Build the app locally
 build: clean 
 	GOOS=linux $(GO) build $(GO_BUILD_FLAGS) -o $(APP_NAME)
-	cd docker && build.sh
+	cp sidecar docker && ./docker/build.sh
 
 .PHONY: release
 release: #: Build and upload the release to GitHub
@@ -36,6 +36,7 @@ release: #: Build and upload the release to GitHub
 clean: #: Clean up build artifacts
 clean:
 	$(RM) ./$(APP_NAME)
+	$(RM) ./docker/$(APP_NAME)
 
 ### Test
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ code-check:
 build: #: Build the app locally
 build: clean 
 	GOOS=linux $(GO) build $(GO_BUILD_FLAGS) -o $(APP_NAME)
-	cp sidecar docker && ./docker/build.sh
+	./docker/build.sh
 
 .PHONY: release
 release: #: Build and upload the release to GitHub

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -86,16 +86,18 @@ func (k *K8sAPIDiscoverer) serviceFromPod(svcName, ip string, pod K8sPod) servic
 		Image:     pod.Image(),
 		Created:   pod.Metadata.CreationTimestamp,
 		Hostname:  pod.Spec.NodeName,
-		ProxyMode: "http",
 		Status:    service.ALIVE,
 		Updated:   time.Now().UTC(),
 	}
 
 	// It's possible to override the default with a ProxyMode label
-	if pod.Metadata.Labels.ProxyMode == "tcp" {
+	switch pod.Metadata.Labels.ProxyMode {
+	case "tcp":
 		svc.ProxyMode = "tcp"
-	} else if pod.Metadata.Labels.ProxyMode == "ws" {
+	case "ws":
 		svc.ProxyMode = "ws"
+	default:
+		svc.ProxyMode = "http"
 	}
 
 	if discovered, ok := k.discoveredSvcs[pod.ServiceName()]; ok {

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -94,9 +94,7 @@ func (k *K8sAPIDiscoverer) serviceFromPod(svcName, ip string, pod K8sPod) servic
 	// It's possible to override the default with a ProxyMode label
 	if pod.Metadata.Labels.ProxyMode == "tcp" {
 		svc.ProxyMode = "tcp"
-	}
-
-	if pod.Metadata.Labels.ProxyMode == "ws" {
+	} else if pod.Metadata.Labels.ProxyMode == "ws" {
 		svc.ProxyMode = "ws"
 	}
 

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -96,6 +96,10 @@ func (k *K8sAPIDiscoverer) serviceFromPod(svcName, ip string, pod K8sPod) servic
 		svc.ProxyMode = "tcp"
 	}
 
+	if pod.Metadata.Labels.ProxyMode == "ws" {
+		svc.ProxyMode = "ws"
+	}
+
 	if discovered, ok := k.discoveredSvcs[pod.ServiceName()]; ok {
 		if discovered.Spec.Ports != nil {
 			for _, port := range discovered.Spec.Ports {


### PR DESCRIPTION
`ws` proxymode is required for websocket services. This PR adds that mode and tidies up the makefile so you don't have to copy round the sidecar binary