### PR TITLE
go 1.26, fix kubernetes service token 401 expiry with refresh, bump alpine

### DIFF
--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -81,13 +81,13 @@ func (k *K8sAPIDiscoverer) servicesForNode(hostname, ip string) []service.Servic
 // serviceFromPod returns a Sidecar service for a K8sPod
 func (k *K8sAPIDiscoverer) serviceFromPod(svcName, ip string, pod K8sPod) service.Service {
 	svc := service.Service{
-		ID:        pod.Metadata.UID,
-		Name:      svcName,
-		Image:     pod.Image(),
-		Created:   pod.Metadata.CreationTimestamp,
-		Hostname:  pod.Spec.NodeName,
-		Status:    service.ALIVE,
-		Updated:   time.Now().UTC(),
+		ID:       pod.Metadata.UID,
+		Name:     svcName,
+		Image:    pod.Image(),
+		Created:  pod.Metadata.CreationTimestamp,
+		Hostname: pod.Spec.NodeName,
+		Status:   service.ALIVE,
+		Updated:  time.Now().UTC(),
 	}
 
 	// It's possible to override the default with a ProxyMode label

--- a/discovery/kubernetes_support.go
+++ b/discovery/kubernetes_support.go
@@ -209,8 +209,9 @@ type KubeAPIDiscoveryCommand struct {
 	Namespace string
 	Timeout   time.Duration
 
-	KubeHost string
-	KubePort int
+	KubeHost  string
+	KubePort  int
+	credsPath string
 
 	token  string
 	client *http.Client
@@ -223,6 +224,7 @@ func NewKubeAPIDiscoveryCommand(kubeHost string, kubePort int, namespace string,
 		Timeout:   timeout,
 		KubeHost:  kubeHost,
 		KubePort:  kubePort,
+		credsPath: credsPath,
 	}
 	// Cache the secret from the file
 	data, err := ioutil.ReadFile(credsPath + "/token")
@@ -263,6 +265,26 @@ func NewKubeAPIDiscoveryCommand(kubeHost string, kubePort int, namespace string,
 	return d
 }
 
+// refreshToken re-reads the service account token from disk. The kubelet
+// rotates this file before the token expires.
+func (d *KubeAPIDiscoveryCommand) refreshToken() error {
+	data, err := ioutil.ReadFile(d.credsPath + "/token")
+	if err != nil {
+		return fmt.Errorf("failed to read serviceaccount token: %w", err)
+	}
+	d.token = strings.Replace(string(data), "\n", "", -1)
+	return nil
+}
+
+func (d *KubeAPIDiscoveryCommand) newRequest(urlStr string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+d.token)
+	return req, nil
+}
+
 func (d *KubeAPIDiscoveryCommand) makeRequest(path string, params string) ([]byte, error) {
 	var scheme = "http"
 	if d.KubePort == 443 {
@@ -275,16 +297,36 @@ func (d *KubeAPIDiscoveryCommand) makeRequest(path string, params string) ([]byt
 		Path:   path,
 	}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s?%s", apiURL.String(), params), nil)
+	fullURL := fmt.Sprintf("%s?%s", apiURL.String(), params)
+
+	req, err := d.newRequest(fullURL)
 	if err != nil {
 		return []byte{}, err
 	}
 
-	req.Header.Set("Authorization", "Bearer "+d.token)
-
 	resp, err := d.client.Do(req)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to fetch from K8s API '%s': %w", path, err)
+	}
+
+	// On 401, refresh the token from disk and retry once
+	if resp.StatusCode == http.StatusUnauthorized {
+		resp.Body.Close()
+
+		log.Warnf("Got 401 from K8s API for '%s', refreshing service account token", path)
+		if err := d.refreshToken(); err != nil {
+			return []byte{}, fmt.Errorf("failed to refresh token after 401: %w", err)
+		}
+
+		req, err = d.newRequest(fullURL)
+		if err != nil {
+			return []byte{}, err
+		}
+
+		resp, err = d.client.Do(req)
+		if err != nil {
+			return []byte{}, fmt.Errorf("failed to fetch from K8s API '%s' after token refresh: %w", path, err)
+		}
 	}
 	defer resp.Body.Close()
 

--- a/discovery/kubernetes_support_test.go
+++ b/discovery/kubernetes_support_test.go
@@ -101,6 +101,43 @@ func Test_makeRequest(t *testing.T) {
 			So(body, ShouldBeEmpty)
 		})
 
+		Convey("refreshes token and retries on 401", func() {
+			callCount := 0
+			httpmock.RegisterResponder("GET", "http://beowulf.example.com:80/nowhere",
+				func(req *http.Request) (*http.Response, error) {
+					callCount++
+					if callCount == 1 {
+						return httpmock.NewJsonResponse(401, map[string]interface{}{"error": "unauthorized"})
+					}
+					return httpmock.NewJsonResponse(200, map[string]interface{}{"success": "yeah"})
+				},
+			)
+
+			capture := LogCapture(func() {
+				body, err := cmd.makeRequest("/nowhere", "")
+				So(err, ShouldBeNil)
+				So(body, ShouldNotBeEmpty)
+			})
+
+			So(callCount, ShouldEqual, 2)
+			So(capture, ShouldContainSubstring, "Got 401 from K8s API")
+		})
+
+		Convey("returns error when retry after 401 also fails", func() {
+			httpmock.RegisterResponder("GET", "http://beowulf.example.com:80/nowhere",
+				httpmock.NewJsonResponderOrPanic(401, map[string]interface{}{"error": "unauthorized"}),
+			)
+
+			capture := LogCapture(func() {
+				body, err := cmd.makeRequest("/nowhere", "")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "got unexpected response code from /nowhere: 401")
+				So(body, ShouldBeEmpty)
+			})
+
+			So(capture, ShouldContainSubstring, "Got 401 from K8s API")
+		})
+
 		Convey("handles error back from http call", func() {
 			httpmock.RegisterResponder("GET", "http://beowulf.example.com:80/nowhere",
 				httpmock.NewErrorResponder(errors.New("intentional test error")),

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM library/alpine:3.20
+FROM library/alpine:3.23
 
 # Necessary depedencies
 RUN apk --update add haproxy bash curl tar s6
@@ -11,4 +11,4 @@ ADD ui /sidecar/ui
 
 EXPOSE 7777
 
-CMD ["/bin/s6-svscan", "/etc/s6"]
+CMD ["/usr/bin/s6-svscan", "/etc/s6"]

--- a/envoy/adapter/adapter.go
+++ b/envoy/adapter/adapter.go
@@ -235,7 +235,7 @@ func connectionManagerForService(svc *service.Service, envoyServiceName string) 
 		manager = &hcm.HttpConnectionManager{
 			StatPrefix: "ingress_http",
 			HttpFilters: []*hcm.HttpFilter{{
-				Name: wellknown.Router,
+				Name:       wellknown.Router,
 				ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: routerConfig},
 			}},
 			RouteSpecifier: &hcm.HttpConnectionManager_RouteConfig{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NinesStack/sidecar
 
-go 1.21
+go 1.26
 
 require (
 	github.com/NinesStack/memberlist v0.0.0-20170522194404-cfac2b5cf519


### PR DESCRIPTION
probably one of our last sidecar patch PRs as we've nearly finished deprecating it in our stack 🥲 

go 1.26
fix kubernetes v1.35 service token 401 expiry with token refresh handler
bump alpine 3.23
fix s6 path


tested, running in dev/prod